### PR TITLE
update deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,6 @@ jobs:
           external_repository: withObsrvr/obsrvr-docs
           publish_branch: main
           publish_dir: ./build
+          cname: docs.withobsrvr.com
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ yarn-error.log*
 .tmp/
 .npm-global/
 .yarn-global/
+
+# docs
+obsrvr-screenshots/
+stripe-screenshots/
+playwright-report/
+.last-run.json


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by specifying a custom domain for documentation deployment.

* Deployment configuration:
  * [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R32): Added the `cname` field to set the custom domain to `docs.withobsrvr.com` when publishing documentation.